### PR TITLE
Only use mime-type as defined on the file in ActiveFedora

### DIFF
--- a/lib/hydra/works/characterization.rb
+++ b/lib/hydra/works/characterization.rb
@@ -10,7 +10,7 @@ module Hydra::Works
 
       def mapper_defaults
         { audio_duration: :duration, audio_sample_rate: :sample_rate, exif_tool_version: :exif_version,
-          file_author: :creator, file_language: :language, file_mime_type: :has_mime_type,
+          file_author: :creator, file_language: :language, file_mime_type: :mime_type,
           video_audio_sample_rate: :sample_rate, video_duration: :duration, video_height: :height,
           video_sample_rate: :sample_rate, video_width: :width }
       end

--- a/lib/hydra/works/characterization/schema/base_schema.rb
+++ b/lib/hydra/works/characterization/schema/base_schema.rb
@@ -8,6 +8,5 @@ module Hydra::Works::Characterization
     property :fits_version, predicate: RDF::Vocab::PREMIS.hasCreatingApplicationVersion
     property :exif_version, predicate: RDF::Vocab::EXIF.exifVersion
     property :original_checksum, predicate: RDF::Vocab::NFO.hashValue
-    property :mime_type, predicate: RDF::Vocab::EBUCore.hasMimeType
   end
 end

--- a/lib/hydra/works/services/characterization_service.rb
+++ b/lib/hydra/works/services/characterization_service.rb
@@ -37,6 +37,7 @@ module Hydra::Works
       def source_to_content
         return object.content if source.nil?
         return File.open(source).read if source.is_a? String
+        source.rewind
         source.read
       end
 
@@ -99,8 +100,8 @@ module Hydra::Works
       end
 
       def append_property_value(property, value)
-        value = object.send(property) + [value]
-        object.send("#{property}=", value.uniq)
+        value = object.send(property) + [value] unless property == :mime_type
+        object.send("#{property}=", value)
       end
   end
 end

--- a/spec/hydra/works/characterization_spec.rb
+++ b/spec/hydra/works/characterization_spec.rb
@@ -10,7 +10,7 @@ describe Hydra::Works::Characterization do
       it { is_expected.to respond_to(:file_name) }
       it { is_expected.to respond_to(:file_size) }
       it { is_expected.to respond_to(:date_created) }
-      it { is_expected.to respond_to(:has_mime_type) }
+      it { is_expected.to respond_to(:mime_type) }
       it { is_expected.to respond_to(:date_modified) }
       it { is_expected.to respond_to(:byte_order) }
     end
@@ -23,7 +23,6 @@ describe Hydra::Works::Characterization do
       it { is_expected.to respond_to(:fits_version) }
       it { is_expected.to respond_to(:exif_version) }
       it { is_expected.to respond_to(:original_checksum) }
-      it { is_expected.to respond_to(:mime_type) }
     end
     context "with Image schema" do
       it { is_expected.to respond_to(:byte_order) }

--- a/spec/hydra/works/services/characterization_service_spec.rb
+++ b/spec/hydra/works/services/characterization_service_spec.rb
@@ -16,9 +16,10 @@ describe Hydra::Works::CharacterizationService do
       expect(file.file_size).to eq(["7618"])
       expect(file.file_title).to eq(["sample-file"])
       expect(file.page_count).to eq(["1"])
-      # Persist and reload from persistence layer
-      expect(file.save).to be nil
-      expect(file.reload).to be nil
+      # Persist our file with some content and reload
+      file.content = "junk"
+      expect(file.save).to be true
+      expect(file.reload).to eq({})
       # Re-check property values
       expect(file.file_size).to eq(["7618"])
       expect(file.file_title).to eq(["sample-file"])
@@ -73,6 +74,7 @@ describe Hydra::Works::CharacterizationService do
       it 'passes the File to FileCharacterization.' do
         file_inst = File.new(File.join(fixture_path, filename))
         expect(Hydra::FileCharacterization).to receive(:characterize).with(file_content, filename, :fits)
+        expect(file_inst).to receive(:rewind)
         described_class.run(file, file_inst)
       end
     end
@@ -151,7 +153,7 @@ describe Hydra::Works::CharacterizationService do
       let(:fits_response) { IO.read(File.join(fixture_path, fits_filename)) }
 
       it 'assigns expected values to audio properties.' do
-        expect(file.has_mime_type).to eq(["audio/mpeg"])
+        expect(file.mime_type).to eq("audio/mpeg")
         expect(file.duration).to eq(["0:0:15:261"])
         expect(file.sample_rate).to eq(["44100"])
       end


### PR DESCRIPTION
This adjusts HydraWorks to align with recent changes in ActiveFedora regarding mime-type. It also addresses a small bug found with using this with Sufia. In passing a File object for upload, the file will have already been read by an ingest job and therefore needs to be rewound to the beginning in order to be read again for characterization.