### PR TITLE
Use plain OM::XML::Document without the datastream

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,7 +14,7 @@ Metrics/LineLength:
 
 Metrics/ClassLength:
   Exclude:
-    - lib/hydra/works/characterization/fits_datastream.rb
+    - lib/hydra/works/characterization/fits_document.rb
 
 Style/CollectionMethods:
   PreferredMethods:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 rvm:
-  - 2.2
+  - 2.2.5
+  - 2.3.1
 before_script:
   - jdk_switcher use oraclejdk8

--- a/hydra-works.gemspec
+++ b/hydra-works.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'hydra-pcdm', '>= 0.8'
   spec.add_dependency 'hydra-derivatives', '~> 3.0'
   spec.add_dependency 'hydra-file_characterization', '~> 0.3', '>= 0.3.3'
+  spec.add_dependency 'om', '~> 3.1'
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/hydra/works.rb
+++ b/lib/hydra/works.rb
@@ -1,6 +1,7 @@
 require 'hydra/works/version'
 require 'hydra/pcdm'
 require 'hydra/derivatives'
+require 'rdf/vocab'
 
 module Hydra
   module Works

--- a/lib/hydra/works/characterization.rb
+++ b/lib/hydra/works/characterization.rb
@@ -16,7 +16,7 @@ module Hydra::Works
       end
     end
 
-    autoload :FitsDatastream, 'hydra/works/characterization/fits_datastream.rb'
+    autoload :FitsDocument, 'hydra/works/characterization/fits_document.rb'
 
     autoload_under 'schema' do
       autoload :AudioSchema

--- a/lib/hydra/works/characterization/fits_document.rb
+++ b/lib/hydra/works/characterization/fits_document.rb
@@ -1,5 +1,7 @@
+require 'om'
+
 module Hydra::Works::Characterization
-  class FitsDatastream < ActiveFedora::OmDatastream
+  class FitsDocument
     include OM::XML::Document
 
     set_terminology do |t|
@@ -87,7 +89,7 @@ module Hydra::Works::Characterization
       # fits_version needs a different name than it's target node since they're at the same level
       t.fits_version(proxy: [:fits, :fits_v])
       t.format_label(proxy: [:identification, :identity, :format_label])
-      # Can't use .mime_type because it's already defined for datastream so method missing won't work.
+      # Can't use .mime_type because it's already defined for this dcoument so method missing won't work.
       t.file_mime_type(proxy: [:identification, :identity, :mime_type])
       t.exif_tool_version(proxy: [:identification, :identity, :tool, :exif_tool_version])
       t.file_size(proxy: [:fileinfo, :file_size])

--- a/spec/hydra/works/models/characterization/fits_document_spec.rb
+++ b/spec/hydra/works/models/characterization/fits_document_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Hydra::Works::Characterization::FitsDatastream do
+describe Hydra::Works::Characterization::FitsDocument do
   it 'defines an xml template' do
     templ = described_class.xml_template.remove_namespaces!
     expect(templ.xpath('/fits/identification/identity/@toolname').first.value).to eq('FITS')

--- a/spec/hydra/works/models/file_set_spec.rb
+++ b/spec/hydra/works/models/file_set_spec.rb
@@ -17,7 +17,7 @@ describe Hydra::Works::FileSet do
 
   describe "#type" do
     it "returns Object and FileSet" do
-      expect(subject.type).to eq [Hydra::PCDM::Vocab::PCDMTerms.Object, Hydra::Works::Vocab::WorksTerms.FileSet]
+      expect(subject.type).to contain_exactly(Hydra::PCDM::Vocab::PCDMTerms.Object, Hydra::Works::Vocab::WorksTerms.FileSet)
     end
   end
 
@@ -34,7 +34,7 @@ describe Hydra::Works::FileSet do
 
     subject { described_class.find(file_set.id).files }
 
-    it { is_expected.to eq [file1, file2] }
+    it { is_expected.to contain_exactly(file1, file2) }
   end
 
   describe '#in_works' do

--- a/spec/hydra/works/services/characterization_service_spec.rb
+++ b/spec/hydra/works/services/characterization_service_spec.rb
@@ -130,7 +130,7 @@ describe Hydra::Works::CharacterizationService do
       it 'assigns expected values to image properties.' do
         expect(file.file_size).to eq(["11043"])
         expect(file.byte_order).to eq(["big endian"])
-        expect(file.compression).to eq(["JPEG 2000 Lossless", "JPEG 2000"])
+        expect(file.compression).to contain_exactly("JPEG 2000 Lossless", "JPEG 2000")
         expect(file.width).to eq(["512"])
         expect(file.height).to eq(["465"])
         expect(file.color_space).to eq(["sRGB"])


### PR DESCRIPTION
This supports ActiveFedora 11 and removes the dependency on OmDatastream.