### PR TITLE
Use services for determining mime type and filename

### DIFF
--- a/lib/hydra/works.rb
+++ b/lib/hydra/works.rb
@@ -51,6 +51,8 @@ module Hydra
       autoload :UploadFileToFileSet
       autoload :PersistDerivative
       autoload :CharacterizationService
+      autoload :DetermineMimeType
+      autoload :DetermineOriginalName
     end
 
     ActiveFedora::WithMetadata::DefaultMetadataClassFactory.file_metadata_schemas +=

--- a/lib/hydra/works/services/determine_mime_type.rb
+++ b/lib/hydra/works/services/determine_mime_type.rb
@@ -1,0 +1,39 @@
+module Hydra::Works
+  class DetermineMimeType
+    # Determines the mime type for a given file
+    # @param [IO, File, Rack::Multipart::UploadedFile, #read] file
+    # @param [String, NilClass] original_name of the file
+    # @return [String]
+    def self.call(file, original_name = nil)
+      new(file, original_name).determine_mime_type
+    end
+
+    attr_reader :file, :original_name
+
+    def initialize(file, original_name)
+      @file = file
+      @original_name = original_name
+    end
+
+    def determine_mime_type
+      return file.mime_type if mime_type?
+      return file.content_type if content_type?
+      mime_type_from_name_or_path || 'application/octet-stream'
+    end
+
+    def mime_type_from_name_or_path
+      return Hydra::PCDM::GetMimeTypeForFile.call(original_name) if original_name.present?
+      return Hydra::PCDM::GetMimeTypeForFile.call(file.path) if file.respond_to?(:path)
+    end
+
+    private
+
+      def mime_type?
+        file.respond_to?(:mime_type) && file.mime_type.present?
+      end
+
+      def content_type?
+        file.respond_to?(:content_type) && file.content_type.present?
+      end
+  end
+end

--- a/lib/hydra/works/services/determine_original_name.rb
+++ b/lib/hydra/works/services/determine_original_name.rb
@@ -1,0 +1,13 @@
+module Hydra::Works
+  class DetermineOriginalName
+    # Determines the original name for a given file
+    # @param [IO, File, Rack::Multipart::UploadedFile, #read] file
+    # @return [String]
+    def self.call(file)
+      return file.original_name if file.respond_to?(:original_name)
+      return file.original_filename if file.respond_to?(:original_filename)
+      return ::File.basename(file.path) if file.respond_to?(:path)
+      ''
+    end
+  end
+end

--- a/spec/hydra/works/services/add_file_to_file_set_spec.rb
+++ b/spec/hydra/works/services/add_file_to_file_set_spec.rb
@@ -67,10 +67,10 @@ describe Hydra::Works::AddFileToFileSet do
     end
   end
 
-  context 'file responds to :path but not to :mime_type nor :original_name' do
-    it 'defaults to Hydra::PCDM for mimetype and ::File for basename.' do
-      expect(Hydra::PCDM::GetMimeTypeForFile).to receive(:call).with(file.path)
-      expect(::File).to receive(:basename).with(file.path)
+  context 'when determining mime type and name' do
+    it 'uses services to assign the values' do
+      expect(Hydra::Works::DetermineOriginalName).to receive(:call).with(file)
+      expect(Hydra::Works::DetermineMimeType).to receive(:call).with(file, nil)
       described_class.call(file_set, file, type)
     end
   end

--- a/spec/hydra/works/services/determine_mime_type_spec.rb
+++ b/spec/hydra/works/services/determine_mime_type_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe Hydra::Works::DetermineMimeType do
+  let(:original_name) { nil }
+  let(:file) { File.open(File.join(fixture_path, 'sample-file.pdf')) }
+
+  subject { described_class.call(file, original_name) }
+
+  context "when file has :mime_type" do
+    before { allow(file).to receive(:mime_type).and_return("mime_type") }
+    it { is_expected.to eq("mime_type") }
+  end
+
+  context "when file has :content_type" do
+    before { allow(file).to receive(:content_type).and_return("content_type") }
+    it { is_expected.to eq("content_type") }
+  end
+
+  context "when file has :path" do
+    it { is_expected.to eq("application/pdf") }
+  end
+
+  context "when an original_name is supplied" do
+    let(:original_name) { "some-other-file.txt" }
+    it { is_expected.to eq("text/plain") }
+  end
+
+  context "when an empty original_name is supplied" do
+    let(:original_name) { "" }
+    it { is_expected.to eq("application/pdf") }
+  end
+
+  context "when all else fails" do
+    before do
+      allow(file).to receive(:respond_to?).with(:mime_type).and_return(false)
+      allow(file).to receive(:respond_to?).with(:content_type).and_return(false)
+      allow(file).to receive(:respond_to?).with(:path).and_return(false)
+    end
+    it { is_expected.to eq("application/octet-stream") }
+  end
+end

--- a/spec/hydra/works/services/determine_original_name_spec.rb
+++ b/spec/hydra/works/services/determine_original_name_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe Hydra::Works::DetermineOriginalName do
+  let(:file) { File.open(File.join(fixture_path, 'sample-file.pdf')) }
+
+  subject { described_class.call(file) }
+
+  context "when file has :original_name" do
+    before { allow(file).to receive(:original_name).and_return("original_name") }
+    it { is_expected.to eq("original_name") }
+  end
+
+  context "when file has :original_filename" do
+    before { allow(file).to receive(:original_filename).and_return("original_filename") }
+    it { is_expected.to eq("original_filename") }
+  end
+
+  context "when file has :path" do
+    it { is_expected.to eq("sample-file.pdf") }
+  end
+
+  context "when all else fails" do
+    before do
+      allow(file).to receive(:respond_to?).with(:original_name).and_return(false)
+      allow(file).to receive(:respond_to?).with(:original_filename).and_return(false)
+      allow(file).to receive(:respond_to?).with(:path).and_return(false)
+    end
+    it { is_expected.to be_empty }
+  end
+end


### PR DESCRIPTION
This will ultimately relate to fixing projecthydra/sufia#2553. We interrogate an incoming object about its original name and mime type, providing a values ffor each based on some logic. Testing this was difficult when it was buried in a private method. This surfaces the methods as services which can be more easily tested, as well as exposed to other consuming applications should they wish to make use of them.