### PR TITLE
Changing how the file is retrieved for virus checking

### DIFF
--- a/lib/hydra/works/services/virus_checker_service.rb
+++ b/lib/hydra/works/services/virus_checker_service.rb
@@ -28,13 +28,24 @@ module Hydra::Works
       # @param [File] file object to retrieve a path for
       def local_path_for_file(file)
         return file.path if file.respond_to?(:path)
+        return file.content.path if file.content.respond_to?(:path)
+
         Tempfile.open('') do |t|
           t.binmode
-          file.stream.each do |chunk|
-            t.write(chunk)
-          end
+          write_to_temp_file(file, t)
           t.close
           t.path
+        end
+      end
+
+      def write_to_temp_file(file, temp_file)
+        if file.new_record?
+          temp_file.write(file.content.read)
+          file.content.rewind
+        else
+          file.stream.each do |chunk|
+            temp_file.write(chunk)
+          end
         end
       end
   end

--- a/spec/hydra/works/services/virus_checker_service_spec.rb
+++ b/spec/hydra/works/services/virus_checker_service_spec.rb
@@ -5,9 +5,11 @@ describe Hydra::Works::VirusCheckerService do
   let(:file) { Hydra::PCDM::File.new }
   let(:virus_checker) { described_class.new(file, system_virus_scanner) }
   let(:datastream) { instance_double "ActiveFedora::File::Streaming::FileBody" }
+  let(:content) { instance_double "File" }
 
   before do
     allow(file).to receive(:stream).and_return(datastream)
+    allow(file).to receive(:content).and_return(content)
     allow(datastream).to receive(:each)
   end
 
@@ -22,14 +24,15 @@ describe Hydra::Works::VirusCheckerService do
 
   context 'with an infected file' do
     context 'that responds to :path' do
-      it 'will return false' do
+      it 'will return true' do
         expect(system_virus_scanner).to receive(:infected?).with('/tmp/file.pdf').and_return(true)
         allow(file).to receive(:path).and_return('/tmp/file.pdf')
         expect(virus_checker.file_has_virus?).to eq(true)
       end
     end
     context 'that does not respond to :path' do
-      it 'will return false' do
+      let(:content) { instance_double "File", read: ["abc123", nil], rewind: true }
+      it 'will return true' do
         expect(system_virus_scanner).to receive(:infected?).with(kind_of(String)).and_return(true)
         allow(file).to receive(:respond_to?).and_call_original
         allow(file).to receive(:respond_to?).with(:path).and_return(false)
@@ -38,17 +41,47 @@ describe Hydra::Works::VirusCheckerService do
     end
   end
 
-  context 'with a clean file' do
+  context 'with a clean unsaved file' do
     context 'that responds to :path' do
-      it 'will return true' do
+      it 'will return false' do
         expect(system_virus_scanner).to receive(:infected?).with('/tmp/file.pdf').and_return(false)
         allow(file).to receive(:path).and_return('/tmp/file.pdf')
         expect(virus_checker.file_has_virus?).to eq(false)
       end
     end
+
+    context "that does not respond to path" do
+      before do
+        allow(file).to receive(:respond_to?).with(:path).and_return(false)
+      end
+      context 'that the content responds to path' do
+        let(:content) { instance_double "File", read: ["abc123", nil], rewind: true, path: "abc123" }
+
+        it 'will return false' do
+          expect(system_virus_scanner).to receive(:infected?).with(kind_of(String)).and_return(false)
+          expect(content).not_to receive(:read)
+          expect(virus_checker.file_has_virus?).to eq(false)
+        end
+      end
+      context "that the content does not respond to path" do
+        let(:content) { instance_double "File", read: ["abc123", nil], rewind: true }
+        it 'will return false' do
+          expect(system_virus_scanner).to receive(:infected?).with(kind_of(String)).and_return(false)
+          expect(file).not_to receive(:stream)
+          expect(virus_checker.file_has_virus?).to eq(false)
+        end
+      end
+    end
+  end
+
+  context "with a clean saved file that does not respond to :path" do
+    before do
+      allow(file).to receive(:new_record?).and_return(false)
+    end
     context 'that does not respond to :path' do
-      it 'will return true' do
+      it 'will return false' do
         expect(system_virus_scanner).to receive(:infected?).with(kind_of(String)).and_return(false)
+        expect(content).not_to receive(:read)
         allow(file).to receive(:respond_to?).and_call_original
         allow(file).to receive(:respond_to?).with(:path).and_return(false)
         expect(virus_checker.file_has_virus?).to eq(false)


### PR DESCRIPTION
fixes #313 
 
 If the content has a path just use that
 If the file is not saved to fedora use the content
 If the file is save use the datastream

This bug was introduced by me in an effort to not read large files into memory.  Unfortunately when the item was not saved the datastream could not be retrieved from fedora. 