### PR TITLE
Moving configuration to initializer

### DIFF
--- a/lib/hydra/works.rb
+++ b/lib/hydra/works.rb
@@ -2,6 +2,7 @@ require 'hydra/works/version'
 require 'hydra/pcdm'
 require 'hydra/derivatives'
 require 'rdf/vocab'
+require 'hydra/works/railtie' if defined?(Rails)
 
 module Hydra
   module Works

--- a/lib/hydra/works/models/concerns/file_set/derivatives.rb
+++ b/lib/hydra/works/models/concerns/file_set/derivatives.rb
@@ -3,11 +3,6 @@ module Hydra::Works
     extend ActiveSupport::Concern
     include Hydra::Derivatives
 
-    included do
-      # Sets output_file_service to PersistDerivative instead of default Hydra::Derivatives::PersistBasicContainedOutputFileService
-      Hydra::Derivatives.output_file_service = Hydra::Works::PersistDerivative
-    end
-
     # Note, these derivatives are being fetched from Fedora, so there may be more
     # network traffic than necessary.  If you want to avoid this, set up a
     # source_file_service that fetches the files locally, as is done in CurationConcerns.

--- a/lib/hydra/works/railtie.rb
+++ b/lib/hydra/works/railtie.rb
@@ -1,0 +1,10 @@
+module Hydra
+  module Works
+    class Railtie < Rails::Railtie
+      initializer "hydra-works.initializer" do
+        # Sets output_file_service to PersistDerivative instead of default Hydra::Derivatives::PersistBasicContainedOutputFileService
+        Hydra::Derivatives.output_file_service = Hydra::Works::PersistDerivative
+      end
+    end
+  end
+end


### PR DESCRIPTION
With the configuration as part of the include block, there is a timing
issue upstream. This works to address that timing issue.

Closes #315