### PR TITLE
Allows adding URL redirects as files

### DIFF
--- a/lib/hydra/works.rb
+++ b/lib/hydra/works.rb
@@ -48,6 +48,7 @@ module Hydra
     autoload_under 'services' do
       autoload :VirusCheckerService
       autoload :AddFileToFileSet
+      autoload :AddExternalFileToFileSet
       autoload :UploadFileToFileSet
       autoload :PersistDerivative
       autoload :CharacterizationService

--- a/lib/hydra/works/services/add_external_file_to_file_set.rb
+++ b/lib/hydra/works/services/add_external_file_to_file_set.rb
@@ -1,22 +1,26 @@
 module Hydra::Works
-  class AddFileToFileSet
+  class AddExternalFileToFileSet
     # Adds a file to the file_set
     # @param [Hydra::PCDM::FileSet] file_set the file will be added to
-    # @param [IO,File,Rack::Multipart::UploadedFile, #read] object that will be the contents. If file responds to :mime_type, :content_type, :original_name, or :original_filename, those will be called to provide metadata.
+    # @param [String] external_file_url URL representing the externally stored file
     # @param [RDF::URI or String] type URI for the RDF.type that identifies the file's role within the file_set
-    # @param [Boolean] update_existing whether to update an existing file if there is one. When set to true, performs a create_or_update. When set to false, always creates a new file within file_set.files.
-    # @param [Boolean] versioning whether to create new version entries (only applicable if +type+ corresponds to a versionable file)
-
-    def self.call(file_set, file, type, update_existing: true, versioning: true)
+    # @param [Hash] opts Options
+    # @option opts [Boolean] :update_existing When set to true, performs a create_or_update. When set to false, always creates a new file within file_set.files.
+    # @option opts [Boolean] :versioning Whether to create new version entries (only applicable if +type+ corresponds to a versionable file)
+    # @option opts [String] :filename A string for the original file name. Defaults to the same value as external_file_url
+    def self.call(file_set, external_file_url, type, opts = {})
       fail ArgumentError, 'supplied object must be a file set' unless file_set.file_set?
-      fail ArgumentError, 'supplied file must respond to read' unless file.respond_to? :read
+
+      update_existing = opts.fetch(:update_existing, true)
+      versioning = opts.fetch(:versioning, true)
+      filename = opts.fetch(:filename, external_file_url)
 
       # TODO: required as a workaround for https://github.com/projecthydra/active_fedora/pull/858
       file_set.save unless file_set.persisted?
 
       updater_class = versioning ? VersioningUpdater : Updater
       updater = updater_class.new(file_set, type, update_existing)
-      status = updater.update(file)
+      status = updater.update(external_file_url, filename)
       status ? file_set : false
     end
 
@@ -30,8 +34,8 @@ module Hydra::Works
 
       # @param [#read] file object that will be interrogated using the methods: :path, :original_name, :original_filename, :mime_type, :content_type
       # None of the attribute description methods are required.
-      def update(file)
-        attach_attributes(file)
+      def update(external_file_url, filename = nil)
+        attach_attributes(external_file_url, filename)
         persist
       end
 
@@ -46,10 +50,10 @@ module Hydra::Works
           end
         end
 
-        def attach_attributes(file)
-          current_file.content = file
-          current_file.original_name = DetermineOriginalName.call(file)
-          current_file.mime_type = DetermineMimeType.call(file, current_file.original_name)
+        def attach_attributes(external_file_url, filename = nil)
+          current_file.content = StringIO.new('')
+          current_file.original_name = filename
+          current_file.mime_type = "message/external-body; access-type=URL; URL=\"#{external_file_url}\""
         end
 
         # @param [Symbol, RDF::URI] the type of association or filter to use

--- a/spec/hydra/works/services/add_external_file_to_file_set_spec.rb
+++ b/spec/hydra/works/services/add_external_file_to_file_set_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe Hydra::Works::AddExternalFileToFileSet do
+  let(:file_set)            { Hydra::Works::FileSet.new }
+  let(:file_set2)           { Hydra::Works::FileSet.new }
+  let(:filename)            { 'sample-file.pdf' }
+  let(:filename2)           { 'updated-file.txt' }
+  let(:original_name)       { 'original-name.pdf' }
+  # let(:file)                { File.open(File.join(fixture_path, filename)) }
+  # let(:file2)               { File.open(File.join(fixture_path, filename2)) }
+  let(:external_file_url)   { "http://foo.org/abc1234" }
+  let(:type)                { ::RDF::URI('http://pcdm.org/use#ExtractedText') }
+  let(:update_existing)     { true }
+  # let(:mime_type)           { 'application/pdf' }
+
+  context 'when file_set is not persisted' do
+    let(:file_set) { Hydra::Works::FileSet.new }
+    it 'saves file_set' do
+      described_class.call(file_set, external_file_url, type)
+      expect(file_set.persisted?).to be true
+    end
+  end
+
+  context 'when file_set is not valid' do
+    before do
+      file_set.save
+      allow(file_set).to receive(:valid?).and_return(false)
+    end
+    it 'returns false' do
+      expect(described_class.call(file_set, external_file_url, type)).to be false
+    end
+  end
+
+  context 'when file set is valid' do
+    before do
+      described_class.call(file_set, external_file_url, type, filename: original_name)
+    end
+
+    subject(:file) { file_set.filter_files_by_type(type).first }
+
+    it 'sets mime type of the File object to message/external body containing external file URL' do
+      expect(file.mime_type).to eq "message/external-body;access-type=URL;url=\"http://foo.org/abc1234\""
+    end
+
+    it 'assigns value of :filename option to the File object' do
+      expect(file.original_name).to eq original_name
+    end
+
+    context 'when no filename is passed in' do
+      before do
+        described_class.call(file_set, external_file_url, type)
+      end
+
+      subject(:file) { file_set.filter_files_by_type(type).last }
+
+      it 'sets filename of File objectd to be the same as the external file url' do
+        expect(file.original_name).to eq external_file_url
+      end
+    end
+  end
+end


### PR DESCRIPTION
This creates a service class called AddExternalFileToFileSet which acts very
similar to AddFileToFileSet, but instead of expecting binary data, it expects a
URL. This URL will go into the external-content header of the Fedora resource,
and Fedora will automatically redirect to that URL.

The motivation is to provide the basis for more advanced external storage
features higher up in the Hydra stack.