### PR TITLE
Removing content read from file input to save memory

### DIFF
--- a/lib/hydra/works/services/characterization_service.rb
+++ b/lib/hydra/works/services/characterization_service.rb
@@ -36,7 +36,8 @@ module Hydra::Works
       # @return content of object if source is nil; otherwise, return a File or the source
       def source_to_content
         return object.content if source.nil?
-        return File.open(source).read if source.is_a? String
+        # do not read the file into memory It could be huge...
+        return File.open(source) if source.is_a? String
         source.rewind
         source.read
       end

--- a/spec/hydra/works/services/characterization_service_spec.rb
+++ b/spec/hydra/works/services/characterization_service_spec.rb
@@ -65,7 +65,7 @@ describe Hydra::Works::CharacterizationService do
     context "using a string path as the source." do
       it 'passes a file with the string as a path to FileCharacterization.' do
         path_on_disk = File.join(fixture_path, filename)
-        expect(Hydra::FileCharacterization).to receive(:characterize).with(file_content, filename, :fits)
+        expect(Hydra::FileCharacterization).to receive(:characterize).with(kind_of(File), filename, :fits)
         described_class.run(file, path_on_disk)
       end
     end


### PR DESCRIPTION
This change reverts a small portion of a larger change. https://github.com/projecthydra/hydra-works/commit/6e0dd6cc27ea64af816049b936515a4ef62ddc9b

When you run read it reads the entire content into memory.  This is not necessary since the File can be passed directly to Hydra::FileCharacterization