### PR TITLE
AddFileToFileSet: fix @param documentation

### DIFF
--- a/lib/hydra/works/services/add_file_to_file_set.rb
+++ b/lib/hydra/works/services/add_file_to_file_set.rb
@@ -2,7 +2,7 @@ module Hydra::Works
   class AddFileToFileSet
     # Adds a file to the file_set
     # @param [Hydra::PCDM::FileSet] file_set the file will be added to
-    # @param [IO,File,Rack::Multipart::UploadedFile, #read] object that will be the contents. If file responds to :mime_type, :content_type, :original_name, or :original_filename, those will be called to provide metadata.
+    # @param [IO,File,Rack::Multipart::UploadedFile, #read] file the object that will be the contents. If file responds to :mime_type, :content_type, :original_name, or :original_filename, those will be called to provide metadata.
     # @param [RDF::URI or String] type URI for the RDF.type that identifies the file's role within the file_set
     # @param [Boolean] update_existing whether to update an existing file if there is one. When set to true, performs a create_or_update. When set to false, always creates a new file within file_set.files.
     # @param [Boolean] versioning whether to create new version entries (only applicable if +type+ corresponds to a versionable file)


### PR DESCRIPTION
It was missing `file`, the parameter name.