### PR TITLE
Removing an exclusion for a non-existent file

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,6 @@ AllCops:
     - '**/Rakefile'
   Exclude:
     - 'vendor/**/*'
-    - 'spec/internal/bin/*'
 
 Metrics/BlockLength:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,6 @@ AllCops:
   Exclude:
     - 'vendor/**/*'
     - 'spec/internal/bin/*'
-    - 'spec/internal/db/schema.rb'
 
 Metrics/BlockLength:
   Exclude:
@@ -65,10 +64,6 @@ RSpec/FilePath:
 
 RSpec/InstanceVariable:
   Enabled: false
-
-RSpec/DescribedClass:
-  Exclude:
-    - spec/hydra/works/models/concerns/generic_file/characterization_spec.rb
 
 RSpec/AnyInstance:
   Exclude:


### PR DESCRIPTION
```ruby
require 'psych'
['.rubocop.yml', '.rubocop_todo.yml'].each do |filename|
begin
  yaml = Psych.load_file(filename)

  def read(node)
    if node.is_a?(Hash)
      node.each_pair do |key, value|
        read(value)
      end
    elsif node.is_a?(Array)
      node.each do |value|
        read(value)
      end
    elsif node.is_a?(String)
      return unless node =~ /.rb\Z/
      return if node =~ /\*/
      return if File.exist?(node)
      puts node
    end
  end
  read(yaml)
rescue
end
end
```