### PR TITLE
Exclude eicar.txt from .gem to avoid false positives from virus scanners

### DIFF
--- a/hydra-works.gemspec
+++ b/hydra-works.gemspec
@@ -2,6 +2,7 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'hydra/works/version'
+DO_NOT_SHIP          = ['spec/fixtures/eicar.txt']
 
 Gem::Specification.new do |spec|
   spec.name          = 'hydra-works'
@@ -13,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/projecthydra-labs/hydra-works'
   spec.license       = 'APACHE2'
 
-  spec.files         = `git ls-files -z`.split("\x0")
+  spec.files         = `git ls-files -z`.split("\x0") - DO_NOT_SHIP    
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']


### PR DESCRIPTION
Fixes issue where `hydra-works-x.y.z.gem` is routinely detected and repaired/quarantined/deleted by Symantec Endpoint Protection and others because of the [EICAR Test String](https://en.wikipedia.org/wiki/EICAR_test_file) that is present in `spec/fixtures`. This PR excludes that fixture from shipping with the gem, but `hydra-works` developers will still need to manually exempt `spec` or `spec/fixtures` from their virus scanner's jurisdiction.